### PR TITLE
Sett orgnr i url

### DIFF
--- a/client/src/Banner/Banner.tsx
+++ b/client/src/Banner/Banner.tsx
@@ -30,7 +30,7 @@ const Banner: React.FunctionComponent<Props> = (
       : [];
 
 
-    const [history, setHistory] = useState<History<LocationState>>(getHistory())
+    const [history] = useState<History<LocationState>>(getHistory())
 
     return (
     <div>

--- a/client/src/Banner/Banner.tsx
+++ b/client/src/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import Bedriftsmeny from "@navikt/bedriftsmeny";
 import "@navikt/bedriftsmeny/lib/bedriftsmeny.css";
 import {
@@ -6,41 +6,52 @@ import {
   RestAltinnOrganisasjoner,
 } from "../integrasjoner/altinnorganisasjon-api";
 import { RestStatus } from "../integrasjoner/rest-status";
-import {createBrowserHistory, createMemoryHistory, History} from "history";
-import LocationState = History.LocationState;
+import { createBrowserHistory, createMemoryHistory, History } from "history";
 import { sendBedriftValgtEvent } from "../amplitude/events";
+import { useRouter } from "next/router";
+import LocationState = History.LocationState;
 
+export interface Organisasjon {
+  Name: string;
+  Type: string;
+  OrganizationNumber: string;
+  OrganizationForm: string;
+  Status: string;
+  ParentOrganizationNumber: any;
+}
 interface Props {
   tittelMedUnderTittel: string | JSX.Element;
   restOrganisasjoner: RestAltinnOrganisasjoner;
 }
 
 const getHistory = () => {
-    if (typeof window === "undefined") return createMemoryHistory();
-    return createBrowserHistory();
-}
+  if (typeof window === "undefined") return createMemoryHistory();
+  return createBrowserHistory();
+};
 
-const Banner: React.FunctionComponent<Props> = (
-  props
-) => {
+const Banner: React.FunctionComponent<Props> = (props) => {
   const { tittelMedUnderTittel, restOrganisasjoner } = props;
   const altinnOrganisasjoner: AltinnOrganisasjon[] =
     restOrganisasjoner.status === RestStatus.Suksess
       ? restOrganisasjoner.data
       : [];
+  const router = useRouter();
 
+  const [history] = useState<History<LocationState>>(getHistory());
+  const onOrganisasjonChange = (organisasjon?: Organisasjon) => {
+    if (organisasjon) {
+      router.push(`?bedrift=${organisasjon.OrganizationNumber}`);
+    }
+    sendBedriftValgtEvent();
+  };
 
-    const [history] = useState<History<LocationState>>(getHistory())
-
-    return (
+  return (
     <div>
       <Bedriftsmeny
         organisasjoner={altinnOrganisasjoner}
         sidetittel={tittelMedUnderTittel}
         history={history}
-        onOrganisasjonChange={() => {
-          sendBedriftValgtEvent();
-        }}
+        onOrganisasjonChange={onOrganisasjonChange}
       />
     </div>
   );

--- a/client/src/Banner/Banner.tsx
+++ b/client/src/Banner/Banner.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import Bedriftsmeny from "@navikt/bedriftsmeny";
 import "@navikt/bedriftsmeny/lib/bedriftsmeny.css";
 import {
@@ -6,23 +6,32 @@ import {
   RestAltinnOrganisasjoner,
 } from "../integrasjoner/altinnorganisasjon-api";
 import { RestStatus } from "../integrasjoner/rest-status";
-import { RouteComponentProps, withRouter } from "react-router-dom";
+import {createBrowserHistory, createMemoryHistory, History} from "history";
+import LocationState = History.LocationState;
 
 interface Props {
   tittelMedUnderTittel: string | JSX.Element;
   restOrganisasjoner: RestAltinnOrganisasjoner;
 }
 
-const Banner: React.FunctionComponent<Props & RouteComponentProps> = (
+const getHistory = () => {
+    if (typeof window === "undefined") return createMemoryHistory();
+    return createBrowserHistory();
+}
+
+const Banner: React.FunctionComponent<Props> = (
   props
 ) => {
-  const { history, tittelMedUnderTittel, restOrganisasjoner } = props;
+  const { tittelMedUnderTittel, restOrganisasjoner } = props;
   const altinnOrganisasjoner: AltinnOrganisasjon[] =
     restOrganisasjoner.status === RestStatus.Suksess
       ? restOrganisasjoner.data
       : [];
 
-  return (
+
+    const [history, setHistory] = useState<History<LocationState>>(getHistory())
+
+    return (
     <div>
       <Bedriftsmeny
         organisasjoner={altinnOrganisasjoner}
@@ -37,4 +46,4 @@ const Banner: React.FunctionComponent<Props & RouteComponentProps> = (
   );
 };
 
-export default withRouter(Banner);
+export default Banner;

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -16,19 +16,20 @@ import { kalkulerInfographicData } from "../Infographic/datatransformasjon";
 import { useAmplitude } from "../amplitude/useAmplitude";
 import { AmplitudeClient } from "../amplitude/client";
 import { sendSidevisningEvent } from "../amplitude/events";
+import { useOrgnr } from "../hooks/useOrgnr";
 
 export const Forside = (props: { amplitudeClient: AmplitudeClient }) => {
   const bredde = 60;
   const høyde = 60;
 
   useAmplitude(props.amplitudeClient);
+  const orgnr = useOrgnr();
 
   useEffect(() => {
     sendSidevisningEvent();
-  }, []);
+  }, [orgnr]);
 
   const sykefraværshistorikk = useSykefraværshistorikk();
-
   const infographicHvisDataOk =
     sykefraværshistorikk.status !== RestStatus.Suksess ? null : (
       <Infographic {...kalkulerInfographicData(sykefraværshistorikk.data)} />

--- a/client/src/hooks/useOrgnr.ts
+++ b/client/src/hooks/useOrgnr.ts
@@ -1,0 +1,12 @@
+import { useRouter } from "next/router";
+
+export const useOrgnr = (): string | undefined => {
+  const router = useRouter();
+  const bedrift = router.query.bedrift as string;
+
+  if (bedrift === null) {
+    return undefined;
+  } else {
+    return bedrift;
+  }
+};

--- a/client/src/hooks/useSykefraværshistorikk.ts
+++ b/client/src/hooks/useSykefraværshistorikk.ts
@@ -4,9 +4,10 @@ import {
   hentRestSykefraværshistorikk,
   RestSykefraværshistorikk,
 } from "../integrasjoner/kvartalsvis-sykefraværshistorikk-api";
+import { useOrgnr } from "./useOrgnr";
 
 export function useSykefraværshistorikk() {
-  const orgnr = "910969439"; // TODO: Hent ut faktisk orgnr
+  const orgnr = useOrgnr();
 
   const [restSykefraværshistorikk, setRestSykefraværshistorikk] =
     useState<RestSykefraværshistorikk>({ status: RestStatus.IkkeLastet });

--- a/client/src/komponenter/Layout/Layout.tsx
+++ b/client/src/komponenter/Layout/Layout.tsx
@@ -5,7 +5,6 @@ import { DecoratorParts } from "../../utils/dekorator";
 import { DecoratorEnv } from "../decorator/DecoratorEnv";
 import React, { useRef } from "react";
 import Banner from "../../Banner/Banner";
-import { Route, Switch } from "react-router";
 import { useAltinnOrganisasjoner } from "../../hooks/useAltinnOrganisasjoner";
 import { Heading, Ingress } from "@navikt/ds-react";
 
@@ -54,16 +53,10 @@ export const Layout = (props: {
         />
       </div>
       <div id="app" className="app">
-        <Switch>
-          {" "}
-          <Route>
-            <Banner
-              tittelMedUnderTittel={tittelMedUndertittel}
-              restOrganisasjoner={restAltinnOrganisasjoner}
-            />
-          </Route>
-        </Switch>
-
+        <Banner
+          tittelMedUnderTittel={tittelMedUndertittel}
+          restOrganisasjoner={restAltinnOrganisasjoner}
+        />
         <div>
           <div ref={layoutContentRef}>{props.children}</div>
         </div>

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,16 +1,6 @@
 import "../styles/globals.scss";
 import type { AppProps } from "next/app";
-import { BrowserRouter, Router } from "react-router-dom";
-import { createMemoryHistory } from "history";
 
-function MyApp({ Component, pageProps }: AppProps) {
-  const history = createMemoryHistory();
-
-  return (
-    <Router history={history}>
-      <Component {...pageProps} />
-    </Router>
-  );
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
 }
-
-export default MyApp;

--- a/client/src/pages/api/[orgnr]/sykefravarshistorikk/kvartalsvis.ts
+++ b/client/src/pages/api/[orgnr]/sykefravarshistorikk/kvartalsvis.ts
@@ -8,7 +8,11 @@ export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<KvartalsvisSykefraværshistorikk[]>
 ) {
-  res.status(200).json(kvartalsvisSykefraværsprosentMock);
+  if (req.query.orgnr as string === "910969439") {
+    res.status(200).json(kvartalsvisSykefraværsprosentMock);
+  } else {
+    res.status(200).json([]);
+  }
 }
 
 const kvartalsvisSykefraværsprosentMock: KvartalsvisSykefraværshistorikk[] = [

--- a/client/src/pages/api/organisasjoner.ts
+++ b/client/src/pages/api/organisasjoner.ts
@@ -23,5 +23,21 @@ export default function handler(
       Status: "Active",
       ParentOrganizationNumber: "111111111",
     },
+    {
+      Name: "Trøndelag Tømmerere",
+      Type: "Enterprise",
+      OrganizationNumber: "211111111",
+      OrganizationForm: "AS",
+      Status: "Active",
+      ParentOrganizationNumber: "",
+    },
+    {
+      Name: "Trøndelag Tømmerere avd. OSLO",
+      Type: "Business",
+      OrganizationNumber: "810969439",
+      OrganizationForm: "BEDR",
+      Status: "Active",
+      ParentOrganizationNumber: "211111111",
+    },
   ]);
 }


### PR DESCRIPTION
Fjernet react router da vi bruker nextjs som har sin egen router-løsning.
Grunnen til at 'Bedriftsmeny' fungerte i sykefraværstatistikk men ikke i min-ia virker til å henge sammen med hvilken router
og dermed hvilken type history som blir brukt med 'Bedriftsmeny'.
Sykefraværstatistikk bruker BrowserRouter som Implisitt kommer med BrowserHistory, mens vi i min-ia prøvde å bruke
Router med MemoryHistory.
Bedriftsmeny ser ut til å kun fungere med BrowserHistory, noe som var litt problematisk da BrowserHistory er avhengig av
'window' objektet som ikke finnes på server når vi bruker static site generation.
