### PR TITLE
La til (midlertidige) hjelpetekster i infographic

### DIFF
--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -38,7 +38,7 @@ export const Forside = (props: { amplitudeClient: AmplitudeClient }) => {
 
   return (
     <div className={styles.forside}>
-      <Alert variant={"info"} className={styles.fullwidth}>
+      <Alert variant={"info"} className={styles.forsideAlert}>
         Vi jobber med å oppdatere sidene våre.
       </Alert>
       {infographicHvisDataOk}

--- a/client/src/Forside/forside.module.scss
+++ b/client/src/Forside/forside.module.scss
@@ -29,6 +29,7 @@
   }
 }
 
-.fullwidth {
+.forsideAlert {
   width: 100%;
+  margin-bottom: 2rem;
 }

--- a/client/src/Infographic/Infographic.tsx
+++ b/client/src/Infographic/Infographic.tsx
@@ -30,7 +30,7 @@ export const Infographic: FunctionComponent<InfographicData> = ({
         tekst={"Sykefraværsprosenten i Norge akkurat nå er: "}
         verdi={sykefraværNorge + "%"}
         hjelpetekst={
-          "Gjennomsnittlig sykefraværsprosent for hele Norge i siste tilgjenglelige kvartal"
+          "Gjennomsnittlig sykefraværsprosent for hele Norge i siste tilgjengelige kvartal"
         }
       />
 

--- a/client/src/Infographic/Infographic.tsx
+++ b/client/src/Infographic/Infographic.tsx
@@ -21,6 +21,7 @@ export const Infographic: FunctionComponent<InfographicData> = ({
   trendStigningstall,
 }) => {
   const ikonstorrelse = { width: "50px", height: "50px" };
+  const bransjeEllerNæring = sykefraværBransje ? "bransje" : "næring";
 
   return (
     <div className={styles.infographicWrapper}>
@@ -28,22 +29,23 @@ export const Infographic: FunctionComponent<InfographicData> = ({
         ikon={<NorwegianFlag {...ikonstorrelse} />}
         tekst={"Sykefraværsprosenten i Norge akkurat nå er: "}
         verdi={sykefraværNorge + "%"}
+        hjelpetekst={
+          "Gjennomsnittlig sykefraværsprosent for hele Norge i siste tilgjenglelige kvartal"
+        }
       />
 
       <InfographicFlis
         ikon={<Bag {...ikonstorrelse} />}
-        tekst={
-          sykefraværBransje
-            ? "Sykefraværsprosenten i din bransje akkurat nå er: "
-            : "Sykefraværsprosenten i din næring akkurat nå er: "
-        }
-        verdi={(sykefraværBransje ? sykefraværBransje : sykefraværNæring) + "%"}
+        tekst={`Sykefraværsprosenten i din ${bransjeEllerNæring} akkurat nå er: `}
+        verdi={(sykefraværBransje ?? sykefraværNæring) + "%"}
+        hjelpetekst={`Gjennomsnittlig sykefraværsprosent for din ${bransjeEllerNæring} i siste tilgjengelige kvartal`}
       />
 
       <InfographicFlis
         ikon={<HealthCase {...ikonstorrelse} />}
         tekst={"Vanligste årsak til sykemelding i Norge er: "}
         verdi={"Muskel- og skjelettplager"}
+        hjelpetekst={"Tallene kommer fra Statens Arbeidsmiljøinstitutt (Stami)"}
       />
 
       <InfographicFlis
@@ -53,13 +55,13 @@ export const Infographic: FunctionComponent<InfographicData> = ({
             {...ikonstorrelse}
           />
         }
-        tekst={
-          sykefraværBransje
-            ? "Sykefraværet i din bransje akkurat nå er "
-            : "Sykefraværet i din næring akkurat nå er "
-        }
+        tekst={`Sykefraværet i din ${bransjeEllerNæring} akkurat nå er `}
         verdi={stigningstallTilTekst(trendStigningstall)}
+        hjelpetekst={
+          "Trenden er regnet ut ved å sammenlikne ditt sykefravær i siste tilgjengelige kvartal med tilsvarende kvartal året før"
+        }
       />
+
       <BodyLong className={styles.oversiktTekst} size="medium">
         Synes du denne informasjonen var bra? På{" "}
         <Link href={"https://arbeidsgiver.nav.no/sykefravarsstatistikk/"}>

--- a/client/src/InfographicFlis/InfographicFlis.tsx
+++ b/client/src/InfographicFlis/InfographicFlis.tsx
@@ -6,6 +6,7 @@ export const InfographicFlis = (props: {
   ikon: ReactNode;
   tekst: string;
   verdi: string;
+  hjelpetekst: string;
 }) => {
   return (
     <div className={styles.infographicFlis}>
@@ -14,9 +15,7 @@ export const InfographicFlis = (props: {
         {props.tekst}
         <span style={{ fontWeight: 700 }}>{props.verdi}</span>
       </Label>
-      <HelpText title="Hvor kommer dette fra?">
-        Informasjonen er hentet fra X sin statistikk fra 2021
-      </HelpText>
+      <HelpText title="Hvor kommer tallet fra?">{props.hjelpetekst}</HelpText>
     </div>
   );
 };


### PR DESCRIPTION
Disse tekstene er ikke diskutert med teamet, men er uansett bedre enn dummy-teksten som ligger i prod i dag. Det blir nok noen endringer i selve tekstene etter hvert. 

<img width="976" alt="image" src="https://user-images.githubusercontent.com/17157469/160416216-faf27155-44ac-40e6-9468-7a720c9bc683.png">
