### PR TITLE
fikse context i dekorator

### DIFF
--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -50,6 +50,7 @@ class MyDocument extends Document<Props> {
       feedback: false,
       urlLookupTable: false,
       breadcrumbs: breadcrumbs,
+      context: "arbeidsgiver",
     });
 
     const language = getDocumentParameter(initialProps, "lang");


### PR DESCRIPTION
Vi har glemt context arbeidsgiver og ble privat brukt som default