### PR TITLE
Fia samarbeidsstatus

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -67,7 +67,7 @@ jobs:
 
   deployAppToDev:
     name: Deploy app to dev
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fjerne-loginservice'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fia-samarbeidsstatus'
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -23,6 +23,8 @@ spec:
       value: production
     - name: SYKEFRAVARSSTATISTIKK_API_AUDIENCE
       value: "dev-fss:arbeidsgiver:sykefravarsstatistikk-api"
+    - name: FIA_ARBEIDSGIVER_AUDIENCE
+      value: "dev-gcp:pia:fia-arbeidsgiver"
     - name: IA_TJENESTER_METRIKKER_AUDIENCE
       value: "dev-gcp:arbeidsgiver:ia-tjenester-metrikker"
     - name: NOTIFIKASJON_API_AUDIENCE
@@ -34,7 +36,7 @@ spec:
     - name: DECORATOR_BREADCRUMB_THIS_PAGE_URL
       value: https://forebygge-fravar.intern.dev.nav.no/forebygge-fravar
     - name: FIA_ARBEIDSGIVER_URL
-      value: https://arbeidsgiver.intern.dev.nav.no/fia-arbeidsgiver
+      value: http://fia-arbeidsgiver.pia/fia-arbeidsgiver
     - name: SAMTALESTOTTE_URL
       value: https://samtalestotte.intern.dev.nav.no
     - name: SYKEFRAVARSSTATISTIKK_URL
@@ -80,6 +82,8 @@ spec:
           cluster: dev-gcp
         - application: notifikasjon-bruker-api
           namespace: fager
+        - application: fia-arbeidsgiver
+          namespace: pia
       external:
         - host: dekoratoren.dev.nav.no
         - host: sykefravarsstatistikk-api.dev-fss-pub.nais.io

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -33,6 +33,8 @@ spec:
       value: dev
     - name: DECORATOR_BREADCRUMB_THIS_PAGE_URL
       value: https://forebygge-fravar.intern.dev.nav.no/forebygge-fravar
+    - name: FIA_ARBEIDSGIVER_URL
+      value: https://arbeidsgiver.intern.dev.nav.no/fia-arbeidsgiver
     - name: SAMTALESTOTTE_URL
       value: https://samtalestotte.intern.dev.nav.no
     - name: SYKEFRAVARSSTATISTIKK_URL

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -33,6 +33,8 @@ spec:
       value: prod
     - name: DECORATOR_BREADCRUMB_THIS_PAGE_URL
       value: https://arbeidsgiver.nav.no/forebygge-fravar
+    - name: FIA_ARBEIDSGIVER_URL
+      value: https://arbeidsgiver.nav.no/fia-arbeidsgiver
     - name: SAMTALESTOTTE_URL
       value: https://arbeidsgiver.nav.no/samtalestotte
     - name: SYKEFRAVARSSTATISTIKK_URL

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -23,6 +23,8 @@ spec:
       value: production
     - name: SYKEFRAVARSSTATISTIKK_API_AUDIENCE
       value: "prod-fss:arbeidsgiver:sykefravarsstatistikk-api"
+    - name: FIA_ARBEIDSGIVER_AUDIENCE
+      value: "prod-gcp:pia:fia-arbeidsgiver"
     - name: IA_TJENESTER_METRIKKER_AUDIENCE
       value: "prod-gcp:arbeidsgiver:ia-tjenester-metrikker"
     - name: NOTIFIKASJON_API_AUDIENCE
@@ -34,7 +36,7 @@ spec:
     - name: DECORATOR_BREADCRUMB_THIS_PAGE_URL
       value: https://arbeidsgiver.nav.no/forebygge-fravar
     - name: FIA_ARBEIDSGIVER_URL
-      value: https://arbeidsgiver.nav.no/fia-arbeidsgiver
+      value: http://fia-arbeidsgiver.pia/fia-arbeidsgiver
     - name: SAMTALESTOTTE_URL
       value: https://arbeidsgiver.nav.no/samtalestotte
     - name: SYKEFRAVARSSTATISTIKK_URL
@@ -82,6 +84,8 @@ spec:
           namespace: fager
         - application: nav-dekoratoren
           namespace: arbeidsgiver
+        - application: fia-arbeidsgiver
+          namespace: pia
       external:
         - host: www.nav.no
         - host: sykefravarsstatistikk-api.prod-fss-pub.nais.io

--- a/client/.env.development
+++ b/client/.env.development
@@ -1,6 +1,7 @@
 DECORATOR_BREADCRUMB_THIS_PAGE_URL=http://localhost:3000/forebygge-fravar
 DECORATOR_ENV=dev
 SAMTALESTOTTE_URL=https://arbeidsgiver.ekstern.dev.nav.no/samtalestotte
+FIA_ARBEIDSGIVER_URL=https://arbeidsgiver.ekstern.dev.nav.no/fia-arbeidsgiver
 SYKEFRAVARSSTATISTIKK_URL=https://arbeidsgiver.ekstern.dev.nav.no/sykefravarsstatistikk
 FOREBYGGINGSPLAN_URL=https://arbeidsgiver.ekstern.dev.nav.no/forebyggingsplan
 MIN_SIDE_ARBEIDSGIVER_URL=https://arbeidsgiver.ekstern.dev.nav.no/min-side-arbeidsgiver

--- a/client/.env.test
+++ b/client/.env.test
@@ -1,6 +1,7 @@
 DECORATOR_BREADCRUMB_THIS_PAGE_URL=https://forebygge-fravar.intern.dev.nav.no/forebygge-fravar
 DECORATOR_ENV=dev
 SAMTALESTOTTE_URL=https://samtalestotte.test.url
+FIA_ARBEIDSGIVER_URL=https://fia-arbeidsgiver.test.url
 SYKEFRAVARSSTATISTIKK_URL=https://sykefravarsstatistikk.test.url
 FOREBYGGINGSPLAN_URL=https://forebyggingsplan.test.url
 MIN_SIDE_ARBEIDSGIVER_URL=https://min-side-arbeidsgiver.test.url

--- a/client/next.config.js
+++ b/client/next.config.js
@@ -50,6 +50,10 @@ const nextConfig = {
         source: "/notifikasjon-bruker-api",
         destination: "http://localhost:3010/forebygge-fravar/notifikasjon-bruker-api",
       },
+      {
+        source: "/fia-arbeidsgiver/:slug*",
+        destination: "http://localhost:3010/forebygge-fravar/fia-arbeidsgiver/:slug*",
+      },
     ];
   },
   async redirects() {

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Heading, ReadMore} from "@navikt/ds-react";
+import styles from "./fiaSamarbeidsstatus.module.scss"
+
+const FiaSamarbeidsstatus: React.FunctionComponent = () => {
+
+    return (
+        <>
+{/*
+            <div className={styles.fiaSamarbeidsstatus}>
+                <ReadMore header={"I forebyggende samarbeid med NAV"}>
+                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                    Samarbeidet er tidsbegrenset og forpliktende.
+                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                    virksomhet
+                    eller lokal NAV-enhet.
+                </ReadMore>
+            </div>
+
+            <div className={styles.fiaSamarbeidsstatus}>
+                <BodyShort>I forebyggende samarbeid med NAV</BodyShort>
+                <HelpText title="Hva betyr forebyggende samarbeid?">
+                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                    Samarbeidet er tidsbegrenset og forpliktende.
+                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                    virksomhet eller
+                    lokal NAV-enhet.
+                </HelpText>
+            </div>
+*/}
+            <div className={styles.fiaSamarbeidsstatus2}>
+                <Heading size={"medium"}>I forebyggende samarbeid med NAV</Heading>
+                <ReadMore header="Hva betyr forebyggende samarbeid?">
+                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                    Samarbeidet er tidsbegrenset og forpliktende.
+                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                    virksomhet eller
+                    lokal NAV-enhet.
+                </ReadMore>
+            </div>
+
+        </>
+    )
+}
+
+export default FiaSamarbeidsstatus

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -11,23 +11,9 @@ interface FiaSamarbeidsstatusProps {
     kjørerMockApp: boolean;
 }
 
-const utleddFiaSamarbeidsstatusMock = (orgnr: string | null) => {
-    return orgnr?.startsWith("9") ?
-        {
-            status: RestStatus.Suksess,
-            data: {
-                orgnr: orgnr,
-                samarbeid: "I_SAMARBEID"
-            }
-        } :
-        {
-            status: RestStatus.Feil
-        }
-}
 const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (props) => {
     const orgnr = useOrgnr();
-    const fiaSamarbeidsstatus =
-        props.kjørerMockApp ? utleddFiaSamarbeidsstatusMock(orgnr) : useFiaSamarbeidsstatus(orgnr, props.fiaArbeidsgiverUrl);
+    const fiaSamarbeidsstatus = useFiaSamarbeidsstatus(orgnr, props.fiaArbeidsgiverUrl, props.kjørerMockApp);
 
     if (fiaSamarbeidsstatus.status === RestStatus.Suksess && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID") {
         return (

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -4,16 +4,9 @@ import styles from "./fiaSamarbeidsstatus.module.scss"
 import { HandsHeart } from "@navikt/ds-icons";
 import { useFiaSamarbeidsstatus } from "./fiaSamarbeidsstatusAPI";
 import { RestStatus } from "../../integrasjoner/rest-status";
-import { useOrgnr } from "../../hooks/useOrgnr";
 
-interface FiaSamarbeidsstatusProps {
-    fiaArbeidsgiverUrl: string;
-    kjørerMockApp: boolean;
-}
-
-const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (props) => {
-    const orgnr = useOrgnr();
-    const fiaSamarbeidsstatus = useFiaSamarbeidsstatus(orgnr, props.fiaArbeidsgiverUrl, props.kjørerMockApp);
+const FiaSamarbeidsstatus: React.FunctionComponent = () => {
+    const fiaSamarbeidsstatus = useFiaSamarbeidsstatus();
 
     if (fiaSamarbeidsstatus.status === RestStatus.Suksess && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID") {
         return (

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -1,45 +1,20 @@
 import React from "react";
-import { Heading, ReadMore} from "@navikt/ds-react";
+import { Heading, ReadMore } from "@navikt/ds-react";
 import styles from "./fiaSamarbeidsstatus.module.scss"
 
 const FiaSamarbeidsstatus: React.FunctionComponent = () => {
 
     return (
-        <>
-{/*
-            <div className={styles.fiaSamarbeidsstatus}>
-                <ReadMore header={"I forebyggende samarbeid med NAV"}>
-                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
-                    Samarbeidet er tidsbegrenset og forpliktende.
-                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
-                    virksomhet
-                    eller lokal NAV-enhet.
-                </ReadMore>
-            </div>
-
-            <div className={styles.fiaSamarbeidsstatus}>
-                <BodyShort>I forebyggende samarbeid med NAV</BodyShort>
-                <HelpText title="Hva betyr forebyggende samarbeid?">
-                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
-                    Samarbeidet er tidsbegrenset og forpliktende.
-                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
-                    virksomhet eller
-                    lokal NAV-enhet.
-                </HelpText>
-            </div>
-*/}
-            <div className={styles.fiaSamarbeidsstatus2}>
-                <Heading size={"medium"}>I forebyggende samarbeid med NAV</Heading>
-                <ReadMore header="Hva betyr forebyggende samarbeid?">
-                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
-                    Samarbeidet er tidsbegrenset og forpliktende.
-                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
-                    virksomhet eller
-                    lokal NAV-enhet.
-                </ReadMore>
-            </div>
-
-        </>
+        <div className={styles.fiaSamarbeidsstatus}>
+            <Heading size={"large"} level={"2"}>Dere er i et forebyggende samarbeid med NAV</Heading>
+            <ReadMore header="Les mer">
+                Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                Samarbeidet er tidsbegrenset og forpliktende.
+                For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                virksomhet eller
+                lokal NAV-enhet.
+            </ReadMore>
+        </div>
     )
 }
 

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -2,37 +2,30 @@ import React from "react";
 import { Heading, ReadMore } from "@navikt/ds-react";
 import styles from "./fiaSamarbeidsstatus.module.scss"
 import { HandsHeart } from "@navikt/ds-icons";
-import { useFiaSamarbeidsstatus } from "./fiaSamarbeidsstatusAPI";
-import { RestStatus } from "../../integrasjoner/rest-status";
 import { sendLesMerÅpnetEvent } from "../../amplitude/events";
 
 const FiaSamarbeidsstatus: React.FunctionComponent = () => {
-    const fiaSamarbeidsstatus = useFiaSamarbeidsstatus();
 
-    if (fiaSamarbeidsstatus.status === RestStatus.Suksess && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID") {
-        return (
-            <div className={styles.fiaSamarbeidsstatus}>
-                <Heading size={"large"} level={"2"} className={styles.fiaSamarbeidsstatusTittelMedIkon}>
-                    <div className={styles.ikonWrapper}>
-                        <HandsHeart aria-hidden/>
-                    </div>
-                    Dere er i et forebyggende samarbeid med NAV
+    return (
+        <div className={styles.fiaSamarbeidsstatus}>
+            <Heading size={"large"} level={"2"} className={styles.fiaSamarbeidsstatusTittelMedIkon}>
+                <div className={styles.ikonWrapper}>
+                    <HandsHeart aria-hidden />
+                </div>
+                Dere er i et forebyggende samarbeid med NAV
 
-                </Heading>
-                <ReadMore header="Les mer" onClick={(e) => {
-                    sendLesMerÅpnetEvent("Dere er i et forebyggende samarbeid med NAV")
-                }}>
-                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
-                    Samarbeidet er tidsbegrenset og forpliktende.
-                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
-                    virksomhet eller
-                    lokal NAV-enhet.
-                </ReadMore>
-            </div>
-        )
-    } else {
-        return null
-    }
+            </Heading>
+            <ReadMore header="Les mer" onClick={(e) => {
+                sendLesMerÅpnetEvent("Dere er i et forebyggende samarbeid med NAV")
+            }}>
+                Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                Samarbeidet er tidsbegrenset og forpliktende.
+                For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                virksomhet eller
+                lokal NAV-enhet.
+            </ReadMore>
+        </div>
+    )
 }
 
 export default FiaSamarbeidsstatus

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -12,7 +12,7 @@ const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (
 
     useEffect(()=> {
         sendVisSamarbeidsstatusEvent(props.status)
-    }, [])
+    }, [props.status])
 
     return (
         <div className={styles.fiaSamarbeidsstatus}>
@@ -23,7 +23,7 @@ const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (
                 Dere er i et forebyggende samarbeid med NAV
 
             </Heading>
-            <ReadMore header="Les mer" onClick={(e) => {
+            <ReadMore header="Les mer" onClick={() => {
                 sendLesMerÅpnetEvent("Dere er i et forebyggende samarbeid med NAV")
             }}>
                 Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -4,6 +4,7 @@ import styles from "./fiaSamarbeidsstatus.module.scss"
 import { HandsHeart } from "@navikt/ds-icons";
 import { useFiaSamarbeidsstatus } from "./fiaSamarbeidsstatusAPI";
 import { RestStatus } from "../../integrasjoner/rest-status";
+import { sendLesMerÅpnetEvent } from "../../amplitude/events";
 
 const FiaSamarbeidsstatus: React.FunctionComponent = () => {
     const fiaSamarbeidsstatus = useFiaSamarbeidsstatus();
@@ -18,7 +19,9 @@ const FiaSamarbeidsstatus: React.FunctionComponent = () => {
                     Dere er i et forebyggende samarbeid med NAV
 
                 </Heading>
-                <ReadMore header="Les mer">
+                <ReadMore header="Les mer" onClick={(e) => {
+                    sendLesMerÅpnetEvent("Dere er i et forebyggende samarbeid med NAV")
+                }}>
                     Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
                     Samarbeidet er tidsbegrenset og forpliktende.
                     For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -1,12 +1,19 @@
 import React from "react";
-import { Heading, ReadMore } from "@navikt/ds-react";
+import {Heading, ReadMore} from "@navikt/ds-react";
 import styles from "./fiaSamarbeidsstatus.module.scss"
+import {HandsHeart} from "@navikt/ds-icons";
 
 const FiaSamarbeidsstatus: React.FunctionComponent = () => {
 
     return (
         <div className={styles.fiaSamarbeidsstatus}>
-            <Heading size={"large"} level={"2"}>Dere er i et forebyggende samarbeid med NAV</Heading>
+            <Heading size={"large"} level={"2"} className={styles.fiaSamarbeidsstatusTittelMedIkon}>
+                <div className={styles.ikonWrapper}>
+                    <HandsHeart aria-hidden/>
+                </div>
+                Dere er i et forebyggende samarbeid med NAV
+
+            </Heading>
             <ReadMore header="Les mer">
                 Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
                 Samarbeidet er tidsbegrenset og forpliktende.

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -1,28 +1,56 @@
 import React from "react";
-import {Heading, ReadMore} from "@navikt/ds-react";
+import { Heading, ReadMore } from "@navikt/ds-react";
 import styles from "./fiaSamarbeidsstatus.module.scss"
-import {HandsHeart} from "@navikt/ds-icons";
+import { HandsHeart } from "@navikt/ds-icons";
+import { useFiaSamarbeidsstatus } from "./fiaSamarbeidsstatusAPI";
+import { RestStatus } from "../../integrasjoner/rest-status";
+import { useOrgnr } from "../../hooks/useOrgnr";
 
-const FiaSamarbeidsstatus: React.FunctionComponent = () => {
+interface FiaSamarbeidsstatusProps {
+    fiaArbeidsgiverUrl: string;
+    kjørerMockApp: boolean;
+}
 
-    return (
-        <div className={styles.fiaSamarbeidsstatus}>
-            <Heading size={"large"} level={"2"} className={styles.fiaSamarbeidsstatusTittelMedIkon}>
-                <div className={styles.ikonWrapper}>
-                    <HandsHeart aria-hidden/>
-                </div>
-                Dere er i et forebyggende samarbeid med NAV
+const utleddFiaSamarbeidsstatusMock = (orgnr: string | null) => {
+    return orgnr?.startsWith("9") ?
+        {
+            status: RestStatus.Suksess,
+            data: {
+                orgnr: orgnr,
+                samarbeid: "I_SAMARBEID"
+            }
+        } :
+        {
+            status: RestStatus.Feil
+        }
+}
+const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (props) => {
+    const orgnr = useOrgnr();
+    const fiaSamarbeidsstatus =
+        props.kjørerMockApp ? utleddFiaSamarbeidsstatusMock(orgnr) : useFiaSamarbeidsstatus(orgnr, props.fiaArbeidsgiverUrl);
 
-            </Heading>
-            <ReadMore header="Les mer">
-                Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
-                Samarbeidet er tidsbegrenset og forpliktende.
-                For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
-                virksomhet eller
-                lokal NAV-enhet.
-            </ReadMore>
-        </div>
-    )
+    if (fiaSamarbeidsstatus.status === RestStatus.Suksess && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID") {
+        return (
+            <div className={styles.fiaSamarbeidsstatus}>
+                <Heading size={"large"} level={"2"} className={styles.fiaSamarbeidsstatusTittelMedIkon}>
+                    <div className={styles.ikonWrapper}>
+                        <HandsHeart aria-hidden/>
+                    </div>
+                    Dere er i et forebyggende samarbeid med NAV
+
+                </Heading>
+                <ReadMore header="Les mer">
+                    Din virksomhet samarbeider med NAV om sykefraværs- og forebyggingsarbeid.
+                    Samarbeidet er tidsbegrenset og forpliktende.
+                    For mer informasjon kan du kontakte ansvarlig for sykefraværs- og forebyggingsarbeid i din
+                    virksomhet eller
+                    lokal NAV-enhet.
+                </ReadMore>
+            </div>
+        )
+    } else {
+        return null
+    }
 }
 
 export default FiaSamarbeidsstatus

--- a/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
+++ b/client/src/Forside/FiaSamarbeidsstatus/FiaSamarbeidsstatus.tsx
@@ -1,10 +1,18 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Heading, ReadMore } from "@navikt/ds-react";
 import styles from "./fiaSamarbeidsstatus.module.scss"
 import { HandsHeart } from "@navikt/ds-icons";
-import { sendLesMerÅpnetEvent } from "../../amplitude/events";
+import { sendLesMerÅpnetEvent, sendVisSamarbeidsstatusEvent } from "../../amplitude/events";
 
-const FiaSamarbeidsstatus: React.FunctionComponent = () => {
+interface FiaSamarbeidsstatusProps{
+    status: string;
+}
+
+const FiaSamarbeidsstatus: React.FunctionComponent<FiaSamarbeidsstatusProps> = (props) => {
+
+    useEffect(()=> {
+        sendVisSamarbeidsstatusEvent(props.status)
+    }, [])
 
     return (
         <div className={styles.fiaSamarbeidsstatus}>

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
@@ -1,0 +1,16 @@
+.fiaSamarbeidsstatus {
+  padding: 1rem;
+  display: flex;
+  gap: .5rem;
+  align-items: center;
+  border: 1px solid black;
+}
+
+.fiaSamarbeidsstatus2 {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+
+  gap: .5rem;
+  border: 1px solid black;
+}

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
@@ -1,16 +1,8 @@
 .fiaSamarbeidsstatus {
   padding: 1rem;
   display: flex;
-  gap: .5rem;
-  align-items: center;
-  border: 1px solid black;
-}
-
-.fiaSamarbeidsstatus2 {
-  padding: 1rem;
-  display: flex;
   flex-direction: column;
-
+  background: var(--a-bg-subtle);
   gap: .5rem;
-  border: 1px solid black;
+  border-radius: var(--a-border-radius-medium);
 }

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatus.module.scss
@@ -6,3 +6,19 @@
   gap: .5rem;
   border-radius: var(--a-border-radius-medium);
 }
+
+.fiaSamarbeidsstatusTittelMedIkon {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.ikonWrapper {
+  display: flex;
+  align-items: center;
+  background-color: var(--a-orange-200);
+  border-radius: 50%;
+  padding: 20px;
+}

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
@@ -1,0 +1,29 @@
+import { RestRessurs } from "../../integrasjoner/rest-status";
+import { useOrgnr } from "../../hooks/useOrgnr";
+import { predefinerteFeilmeldinger } from "../../utils/logger";
+import { useRestRessursSWR } from "../../hooks/useRestRessursSWR";
+
+export interface FiaSamarbeidsstatusDto {
+    orgnr: string;
+    samarbeid: FiaSamarbeidsstatus;
+}
+
+export type FiaSamarbeidsstatus =
+    | "IKKE_I_SAMARBEID"
+    | "I_SAMARBEID"
+
+export function useFiaSamarbeidsstatus(
+    orgnr: string | null,
+    fiaArbeidsgiverUrl: string
+): RestRessurs<FiaSamarbeidsstatusDto> {
+    const gyldigOrgnr = useOrgnr();
+
+    const apiPath = gyldigOrgnr
+        ? `${fiaArbeidsgiverUrl}/status/${gyldigOrgnr}`
+        : null;
+
+    const errorMessage =
+        predefinerteFeilmeldinger.feilVedHentingAvAggregertStatistikk;
+
+    return useRestRessursSWR<FiaSamarbeidsstatusDto>(apiPath, errorMessage);
+}

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
@@ -2,6 +2,7 @@ import { RestRessurs, RestStatus } from "../../integrasjoner/rest-status";
 import { useOrgnr } from "../../hooks/useOrgnr";
 import { predefinerteFeilmeldinger } from "../../utils/logger";
 import { useRestRessursSWR } from "../../hooks/useRestRessursSWR";
+import { BASE_PATH } from "../../utils/konstanter";
 
 export interface FiaSamarbeidsstatusDto {
     orgnr: string;
@@ -12,33 +13,11 @@ export type FiaSamarbeidsstatus =
     | "IKKE_I_SAMARBEID"
     | "I_SAMARBEID"
 
-const utleddFiaSamarbeidsstatusMock = (orgnr: string): RestRessurs<FiaSamarbeidsstatusDto> => {
-    return orgnr?.startsWith("9") ?
-        {
-            status: RestStatus.Suksess,
-            data: {
-                orgnr: orgnr,
-                samarbeid: "I_SAMARBEID"
-            }
-        } :
-        {
-            status: RestStatus.Feil,
-        }
-}
-
-export function useFiaSamarbeidsstatus(
-    orgnr: string | null,
-    fiaArbeidsgiverUrl: string,
-    kjørerMockApp: boolean,
-): RestRessurs<FiaSamarbeidsstatusDto> {
+export function useFiaSamarbeidsstatus(): RestRessurs<FiaSamarbeidsstatusDto> {
     const gyldigOrgnr = useOrgnr();
 
-    if (kjørerMockApp && gyldigOrgnr) {
-        return utleddFiaSamarbeidsstatusMock(gyldigOrgnr);
-    }
-
     const apiPath = gyldigOrgnr
-        ? `${fiaArbeidsgiverUrl}/status/${gyldigOrgnr}`
+        ? `${BASE_PATH}/fia-arbeidsgiver/${gyldigOrgnr}`
         : null;
 
     const errorMessage =

--- a/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
+++ b/client/src/Forside/FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI.ts
@@ -1,4 +1,4 @@
-import { RestRessurs } from "../../integrasjoner/rest-status";
+import { RestRessurs, RestStatus } from "../../integrasjoner/rest-status";
 import { useOrgnr } from "../../hooks/useOrgnr";
 import { predefinerteFeilmeldinger } from "../../utils/logger";
 import { useRestRessursSWR } from "../../hooks/useRestRessursSWR";
@@ -12,11 +12,30 @@ export type FiaSamarbeidsstatus =
     | "IKKE_I_SAMARBEID"
     | "I_SAMARBEID"
 
+const utleddFiaSamarbeidsstatusMock = (orgnr: string): RestRessurs<FiaSamarbeidsstatusDto> => {
+    return orgnr?.startsWith("9") ?
+        {
+            status: RestStatus.Suksess,
+            data: {
+                orgnr: orgnr,
+                samarbeid: "I_SAMARBEID"
+            }
+        } :
+        {
+            status: RestStatus.Feil,
+        }
+}
+
 export function useFiaSamarbeidsstatus(
     orgnr: string | null,
-    fiaArbeidsgiverUrl: string
+    fiaArbeidsgiverUrl: string,
+    kjørerMockApp: boolean,
 ): RestRessurs<FiaSamarbeidsstatusDto> {
     const gyldigOrgnr = useOrgnr();
+
+    if (kjørerMockApp && gyldigOrgnr) {
+        return utleddFiaSamarbeidsstatusMock(gyldigOrgnr);
+    }
 
     const apiPath = gyldigOrgnr
         ? `${fiaArbeidsgiverUrl}/status/${gyldigOrgnr}`

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -12,6 +12,7 @@ import { AndreForebyggendeVerktoy } from "./AndreForebyggendeVerktøy/AndreForeb
 import { RelaterteTjenester } from "./RelaterteTjenester/RelaterteTjenester";
 import { Sykefraværsstatistikk } from "./Sykefraværsstatistikk/Sykefraværsstatistikk";
 import { KontaktOss } from "./KontaktOss/KontaktOss";
+import FiaSamarbeidsstatus from "./FiaSamarbeidsstatus/FiaSamarbeidsstatus";
 
 export interface ForsideProps {
   samtalestøtteUrl: string;
@@ -52,6 +53,7 @@ export const Forside = (props: ForsideProps) => {
       <div className={styles.forside}>
         {props.children}
         {sykefraværsstatistikkEllerBannerHvisError}
+        <FiaSamarbeidsstatus/>
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -19,6 +19,8 @@ export interface ForsideProps {
   forebyggingsplanUrl: string;
   sykefraværsstatistikkUrl: string;
   kontaktOssUrl: string;
+  fiaArbeidsgiverUrl: string;
+  kjørerMockApp: boolean;
   children?: React.ReactNode;
 }
 
@@ -54,7 +56,7 @@ export const Forside = (props: ForsideProps) => {
         {props.children}
         {sykefraværsstatistikkEllerBannerHvisError}
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
-        <FiaSamarbeidsstatus/>
+        <FiaSamarbeidsstatus kjørerMockApp={props.kjørerMockApp} fiaArbeidsgiverUrl={props.fiaArbeidsgiverUrl}/>
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />
         <KontaktOss kontaktOssUrl={props.kontaktOssUrl} />

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -56,7 +56,7 @@ export const Forside = (props: ForsideProps) => {
         {props.children}
         {sykefraværsstatistikkEllerBannerHvisError}
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
-        <FiaSamarbeidsstatus kjørerMockApp={props.kjørerMockApp} fiaArbeidsgiverUrl={props.fiaArbeidsgiverUrl}/>
+        <FiaSamarbeidsstatus />
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />
         <KontaktOss kontaktOssUrl={props.kontaktOssUrl} />

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -13,6 +13,7 @@ import { RelaterteTjenester } from "./RelaterteTjenester/RelaterteTjenester";
 import { Sykefraværsstatistikk } from "./Sykefraværsstatistikk/Sykefraværsstatistikk";
 import { KontaktOss } from "./KontaktOss/KontaktOss";
 import FiaSamarbeidsstatus from "./FiaSamarbeidsstatus/FiaSamarbeidsstatus";
+import { useFiaSamarbeidsstatus } from "./FiaSamarbeidsstatus/fiaSamarbeidsstatusAPI";
 
 export interface ForsideProps {
   samtalestøtteUrl: string;
@@ -50,13 +51,17 @@ export const Forside = (props: ForsideProps) => {
       />
     );
 
+  const fiaSamarbeidsstatus = useFiaSamarbeidsstatus();
+
   return (
     <div className={styles.sentrertSide}>
       <div className={styles.forside}>
         {props.children}
         {sykefraværsstatistikkEllerBannerHvisError}
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
-        <FiaSamarbeidsstatus />
+        {fiaSamarbeidsstatus.status === RestStatus.Suksess
+            && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID"
+            && <FiaSamarbeidsstatus />}
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />
         <KontaktOss kontaktOssUrl={props.kontaktOssUrl} />

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -61,7 +61,7 @@ export const Forside = (props: ForsideProps) => {
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
         {fiaSamarbeidsstatus.status === RestStatus.Suksess
             && fiaSamarbeidsstatus.data.samarbeid === "I_SAMARBEID"
-            && <FiaSamarbeidsstatus />}
+            && <FiaSamarbeidsstatus status={fiaSamarbeidsstatus.data.samarbeid} />}
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />
         <KontaktOss kontaktOssUrl={props.kontaktOssUrl} />

--- a/client/src/Forside/Forside.tsx
+++ b/client/src/Forside/Forside.tsx
@@ -53,8 +53,8 @@ export const Forside = (props: ForsideProps) => {
       <div className={styles.forside}>
         {props.children}
         {sykefraværsstatistikkEllerBannerHvisError}
-        <FiaSamarbeidsstatus/>
         <NyttVerktoyTilDeg href={props.forebyggingsplanUrl} />
+        <FiaSamarbeidsstatus/>
         <AndreForebyggendeVerktoy href={samtalestøtteUrlMedOrgnr} />
         <RelaterteTjenester />
         <KontaktOss kontaktOssUrl={props.kontaktOssUrl} />

--- a/client/src/amplitude/events.ts
+++ b/client/src/amplitude/events.ts
@@ -21,6 +21,10 @@ export const sendLesMerÅpnetEvent = (name: string) => {
   logEvent("les mer åpnet", {name});
 };
 
+export const sendVisSamarbeidsstatusEvent = (status: string) => {
+  logEvent("vis samarbeidsstatus", {status});
+};
+
 export const sendNavigereEvent = (
   destinasjon: string,
   lenketekst: string

--- a/client/src/amplitude/events.ts
+++ b/client/src/amplitude/events.ts
@@ -17,8 +17,8 @@ export const sendInputfeltUtfyltEvent = (label: string, name: string) => {
   logEvent("textField utfylt", { label, name });
 };
 
-export const sendLesMerÅpnetEvent = (name: string) => {
-  logEvent("les mer åpnet", {name});
+export const sendLesMerÅpnetEvent = (emne: string) => {
+  logEvent("les mer åpnet", {emne: emne});
 };
 
 export const sendVisSamarbeidsstatusEvent = (status: string) => {

--- a/client/src/amplitude/events.ts
+++ b/client/src/amplitude/events.ts
@@ -17,6 +17,10 @@ export const sendInputfeltUtfyltEvent = (label: string, name: string) => {
   logEvent("textField utfylt", { label, name });
 };
 
+export const sendLesMerÅpnetEvent = (name: string) => {
+  logEvent("les mer åpnet", {name});
+};
+
 export const sendNavigereEvent = (
   destinasjon: string,
   lenketekst: string

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -83,6 +83,8 @@ export const getServerSideProps = async () => {
     forebyggingsplanUrl: hentUrlFraMiljøvariabel("Forebyggingsplan"),
     sykefraværsstatistikkUrl: hentUrlFraMiljøvariabel("Sykefraværsstatistikk"),
     kontaktOssUrl: hentUrlFraMiljøvariabel("Kontakt Oss"),
+    fiaArbeidsgiverUrl: hentUrlFraMiljøvariabel("Fia-arbeidsgiver"),
+    kjørerMockApp,
   };
 
   const props: HomeProps = {

--- a/client/src/utils/envUtils.ts
+++ b/client/src/utils/envUtils.ts
@@ -7,6 +7,7 @@ export const isMockApp = () => {
 };
 
 export type Tjeneste =
+  | "Fia-arbeidsgiver"
   | "Sykefraværsstatistikk"
   | "Forebyggingsplan"
   | "Samtalestøtte"
@@ -16,6 +17,9 @@ export type Tjeneste =
 export const hentUrlFraMiljøvariabel = (tjeneste: Tjeneste) => {
   let url;
   switch (tjeneste) {
+    case "Fia-arbeidsgiver":
+      url = process.env.FIA_ARBEIDSGIVER_URL;
+      break;
     case "Sykefraværsstatistikk":
       url = process.env.SYKEFRAVARSSTATISTIKK_URL;
       break;

--- a/server/src/local/fia-arbeidsgiverMock.ts
+++ b/server/src/local/fia-arbeidsgiverMock.ts
@@ -1,0 +1,6 @@
+export const fiaArbeidsgiverMock = (orgnr: string) => {
+    return {
+        orgnr: orgnr,
+        samarbeid: orgnr.startsWith("9") ? "IKKE_I_SAMARBEID" : "I_SAMARBEID"
+    }
+}

--- a/server/src/local/proxyMiddlewareMock.ts
+++ b/server/src/local/proxyMiddlewareMock.ts
@@ -9,6 +9,7 @@ import {
   mockdataOrgnr91096939,
   tomRespons,
 } from "./aggregertStatistikkMockdata.js";
+import { fiaArbeidsgiverMock } from "./fia-arbeidsgiverMock";
 
 export const backendApiProxyMock = (server: Express) => {
   console.log("========================================");
@@ -106,5 +107,10 @@ export const backendApiProxyMock = (server: Express) => {
 
   server.get(`/forebygge-fravar/kursoversikt`, (request, response) => {
     response.send(kurslisteMock);
+  });
+
+  server.get(`/forebygge-fravar/fia-arbeidsgiver/:orgnr`, (request, response) => {
+    const orgnr = request.params.orgnr;
+    response.send(fiaArbeidsgiverMock(orgnr));
   });
 };

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -12,7 +12,9 @@ import { isAlive, isReady } from "./healthcheck.js";
 import { isMockApp } from "./util/environment";
 import {
   applyNotifikasjonMiddleware,
-  setupBackendApiProxy, setupIaTjenestermetrikkerProxy,
+  setupBackendApiProxy,
+  setupFiaArbeidsgiverProxy,
+  setupIaTjenestermetrikkerProxy,
   setupKursoversiktApiProxy,
   setupNotifikasjonBrukerAPIProxyMock
 } from "./config/middleware/proxyMiddleware";
@@ -42,6 +44,7 @@ const initServer = async () => {
     setupBackendApiProxy(server);
     setupKursoversiktApiProxy(server);
     setupIaTjenestermetrikkerProxy(server);
+    setupFiaArbeidsgiverProxy(server);
     applyNotifikasjonMiddleware(server);
   }
 


### PR DESCRIPTION
Ny flis "Dere er i et forebyggende samarbeid med NAV" på Forebygge fravær: 
 - komponent Fia-samarbeidsstatus vises dersom underenhet har en sak med status "Vi bistår" i FIA
 - "Les mer" som forklarer hva forebyggende samarbeid med NAV innebærer
 - amplitude måling ved: visning av Fia-samarbeidsstatus og klick på "Les mer"