### PR TITLE
La til en fiks så dependabot ikke kjører docker push.

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Build
         run: yarn build
       - name: Push to Google Artifact Registry
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: nais/docker-build-push@v0
         id: docker-push
         with:


### PR DESCRIPTION
Vi kan ikke merge inn fikser fra dependabot, siden den failer på build/push til docker. Nå skal den ikke prøve å pushe til docker, og forhåpentligvis kunne merges.