### PR TITLE
Endre på loggnivå for 'token is invalid' melding

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - next-15
+      - endre-logg-niva-ved-validering-av-token
     paths-ignore:
       - "**.md"
       - "**/**.md"

--- a/src/utils/api-proxy.ts
+++ b/src/utils/api-proxy.ts
@@ -19,7 +19,7 @@ export default async function proxyRequestWithTokenExchange(
   const newAuthToken = await exchangeIdportenSubjectToken(req, audience);
 
   if (isInvalidToken(newAuthToken)) {
-    backendLogger.error("token is invalid");
+      backendLogger.info(`Token er ikke gyldig. Kan skyldes at bruker ikke er innlogget, token har gått ut eller feil ved verifisering av tokenet. Årsak: ${newAuthToken.errorType}`);
     return res.status(401).json({ error: "authentication failed" });
   }
 


### PR DESCRIPTION
Endre på loggnivå for 'token is invalid' melding fra 'error' til 'info' da denne meldingen dukker opp hver gang en bruker kommer på våre sider uinnlogget (og gjelder alle requests mot backend)
Dette er vanlig flytt. Brukeren vil få en 403 + redirect til innlogging. Ikke en error. Endre også meldingen (forklarer hvorfor vi logger denne)