### PR TITLE
Midlertidig er v2 flag

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - vise-label-bransje-eller-næring
+      - midlertidig-erV2-flag
     paths-ignore:
       - "**.md"
       - "**/**.md"

--- a/src/hooks/useAggregertStatistikk.ts
+++ b/src/hooks/useAggregertStatistikk.ts
@@ -3,12 +3,12 @@ import { AggregertStatistikkDto } from "../integrasjoner/aggregert-statistikk-ap
 import { useOrgnr } from "./useOrgnr";
 import {API_BASE_PATH_V2, SYKEFRAVARSSTATISTIKK_BASE_PATH} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
-import {usePath} from "./usePath";
+import {useApiPath} from "./useApiPath";
 
 export function useAggregertStatistikk(): RestRessurs<AggregertStatistikkDto> {
   const gyldigOrgnr = useOrgnr();
 
-  const path = usePath(
+  const path = useApiPath(
       `${API_BASE_PATH_V2}/aggregert?orgnr=${gyldigOrgnr}`,
       `${SYKEFRAVARSSTATISTIKK_BASE_PATH}/aggregert?orgnr=${gyldigOrgnr}`
   );

--- a/src/hooks/useAggregertStatistikk.ts
+++ b/src/hooks/useAggregertStatistikk.ts
@@ -1,14 +1,20 @@
 import { RestRessurs } from "../integrasjoner/rest-status";
 import { AggregertStatistikkDto } from "../integrasjoner/aggregert-statistikk-api";
 import { useOrgnr } from "./useOrgnr";
-import { SYKEFRAVARSSTATISTIKK_BASE_PATH } from "../utils/konstanter";
+import {API_BASE_PATH_V2, SYKEFRAVARSSTATISTIKK_BASE_PATH} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
+import {usePath} from "./usePath";
 
 export function useAggregertStatistikk(): RestRessurs<AggregertStatistikkDto> {
   const gyldigOrgnr = useOrgnr();
 
+  const path = usePath(
+      `${API_BASE_PATH_V2}/aggregert?orgnr=${gyldigOrgnr}`,
+      `${SYKEFRAVARSSTATISTIKK_BASE_PATH}/aggregert?orgnr=${gyldigOrgnr}`
+  );
+
   const apiPath = gyldigOrgnr
-    ? `${SYKEFRAVARSSTATISTIKK_BASE_PATH}/aggregert?orgnr=${gyldigOrgnr}`
+      ? path
     : null;
 
   return useRestRessursSWR<AggregertStatistikkDto>(

--- a/src/hooks/useApiPath.ts
+++ b/src/hooks/useApiPath.ts
@@ -1,4 +1,4 @@
-export const usePath = (v2Path: string, defaultPath: string): string => {
+export const useApiPath = (v2Path: string, defaultPath: string): string => {
     let erV2 = false;
     if (typeof window !== 'undefined') {
         erV2 = localStorage.getItem("erV2") === "true";

--- a/src/hooks/useApiPath.ts
+++ b/src/hooks/useApiPath.ts
@@ -2,7 +2,6 @@ export const useApiPath = (v2Path: string, defaultPath: string): string => {
     let erV2 = false;
     if (typeof window !== 'undefined') {
         erV2 = localStorage.getItem("erV2") === "true";
-        console.log(`[DEBUG] erV2: ${erV2}`);
     }
 
     return erV2 ? v2Path : defaultPath;

--- a/src/hooks/useKvartalsvisStatistikk.ts
+++ b/src/hooks/useKvartalsvisStatistikk.ts
@@ -3,13 +3,13 @@ import { useOrgnr } from "./useOrgnr";
 import {API_BASE_PATH, API_BASE_PATH_V2} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
 import { KvartalsvisSykefraværshistorikk } from "../sykefravarsstatistikk/hooks/useSykefraværAppData";
-import {usePath} from "./usePath";
+import {useApiPath} from "./useApiPath";
 
 export function useKvartalsvisStatistikk(): RestRessurs<
   KvartalsvisSykefraværshistorikk[]
 > {
   const gyldigOrgnr = useOrgnr();
-  const path = usePath(
+  const path = useApiPath(
       `${API_BASE_PATH_V2}/kvartalsvis?orgnr=${gyldigOrgnr}`,
       `${API_BASE_PATH}/sykefravarsstatistikk-api/kvartalsvis-sykefravarshistorikk?orgnr=${gyldigOrgnr}`
   );

--- a/src/hooks/useKvartalsvisStatistikk.ts
+++ b/src/hooks/useKvartalsvisStatistikk.ts
@@ -1,16 +1,20 @@
 import { RestRessurs } from "../integrasjoner/rest-status";
 import { useOrgnr } from "./useOrgnr";
-import { API_BASE_PATH } from "../utils/konstanter";
+import {API_BASE_PATH, API_BASE_PATH_V2} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
 import { KvartalsvisSykefraværshistorikk } from "../sykefravarsstatistikk/hooks/useSykefraværAppData";
+import {usePath} from "./usePath";
 
 export function useKvartalsvisStatistikk(): RestRessurs<
   KvartalsvisSykefraværshistorikk[]
 > {
   const gyldigOrgnr = useOrgnr();
-
+  const path = usePath(
+      `${API_BASE_PATH_V2}/kvartalsvis?orgnr=${gyldigOrgnr}`,
+      `${API_BASE_PATH}/sykefravarsstatistikk-api/kvartalsvis-sykefravarshistorikk?orgnr=${gyldigOrgnr}`
+  );
   const apiPath = gyldigOrgnr
-    ? `${API_BASE_PATH}/sykefravarsstatistikk-api/kvartalsvis-sykefravarshistorikk?orgnr=${gyldigOrgnr}`
+      ? path
     : null;
 
   return useRestRessursSWR<KvartalsvisSykefraværshistorikk[]>(

--- a/src/hooks/usePath.ts
+++ b/src/hooks/usePath.ts
@@ -1,0 +1,9 @@
+export const usePath = (v2Path: string, defaultPath: string): string => {
+    let erV2 = false;
+    if (typeof window !== 'undefined') {
+        erV2 = localStorage.getItem("erV2") === "true";
+        console.log(`[DEBUG] erV2: ${erV2}`);
+    }
+
+    return erV2 ? v2Path : defaultPath;
+};

--- a/src/hooks/usePubliseringsdato.ts
+++ b/src/hooks/usePubliseringsdato.ts
@@ -1,10 +1,14 @@
 import { RestRessurs } from "../integrasjoner/rest-status";
-import { API_BASE_PATH } from "../utils/konstanter";
+import {API_BASE_PATH, API_BASE_PATH_V2} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
 import { SerialiserbarPubliseringsdatoer } from "../sykefravarsstatistikk/hooks/useSykefraværAppData";
+import {usePath} from "./usePath";
 
 export function usePubliseringsdato(): RestRessurs<SerialiserbarPubliseringsdatoer> {
-  const apiPath = `${API_BASE_PATH}/sykefravarsstatistikk-api/publiseringsdato`;
+    const apiPath = usePath(
+        `${API_BASE_PATH_V2}/publiseringsdato`,
+        `${API_BASE_PATH}/sykefravarsstatistikk-api/publiseringsdato`
+    );
 
   return useRestRessursSWR<SerialiserbarPubliseringsdatoer>(
     apiPath,

--- a/src/hooks/usePubliseringsdato.ts
+++ b/src/hooks/usePubliseringsdato.ts
@@ -2,10 +2,10 @@ import { RestRessurs } from "../integrasjoner/rest-status";
 import {API_BASE_PATH, API_BASE_PATH_V2} from "../utils/konstanter";
 import { useRestRessursSWR } from "./useRestRessursSWR";
 import { SerialiserbarPubliseringsdatoer } from "../sykefravarsstatistikk/hooks/useSykefraværAppData";
-import {usePath} from "./usePath";
+import {useApiPath} from "./useApiPath";
 
 export function usePubliseringsdato(): RestRessurs<SerialiserbarPubliseringsdatoer> {
-    const apiPath = usePath(
+    const apiPath = useApiPath(
         `${API_BASE_PATH_V2}/publiseringsdato`,
         `${API_BASE_PATH}/sykefravarsstatistikk-api/publiseringsdato`
     );

--- a/src/local/mock.ts
+++ b/src/local/mock.ts
@@ -20,10 +20,10 @@ export default async function mockRequest(req: NextRequest) {
   const delayInMillis = 500;
 
   if (
-    req.url?.endsWith("/api/authenticated/sykefravarsstatistikk/organisasjoner")
+      req.url?.endsWith("/organisasjoner")
   ) {
     console.log(
-      "[DEBUG] GET /api/authenticated/sykefravarsstatistikk/organisasjoner"
+        "[DEBUG] GET /api/[...]/organisasjoner"
     );
 
     switch (testMode) {
@@ -40,11 +40,11 @@ export default async function mockRequest(req: NextRequest) {
 
   if (
     req.url?.endsWith(
-      "/api/authenticated/sykefravarsstatistikk/organisasjoner-med-statistikktilgang"
+        "/organisasjoner-med-statistikktilgang"
     )
   ) {
     console.log(
-      "[DEBUG] GET /api/authenticated/sykefravarsstatistikk/organisasjoner-med-statistikktilgang"
+        "[DEBUG] GET /api/[...]/organisasjoner-med-statistikktilgang"
     );
 
     switch (testMode) {
@@ -100,14 +100,11 @@ export default async function mockRequest(req: NextRequest) {
     });
   }
 
-  if (
-    req.url?.includes(
-      "/api/sykefravarsstatistikk-api/kvartalsvis-sykefravarshistorikk?orgnr="
-    )
+  if (req.nextUrl.pathname.includes("/api/sykefravarsstatistikk-api/kvartalsvis-sykefravarshistorikk")
+      || req.nextUrl.pathname.includes("/api/authenticated/sykefravarsstatistikk/v2/kvartalsvis")
   ) {
-    const orgnr = req.nextUrl.searchParams.get("orgnr") as string;
     console.log(
-      `[DEBUG] GET /api/sykefravarsstatistikk-api/kvartalsvis-sykefraværshistorikk?orgnr=${orgnr}`
+        `[DEBUG] GET ${req.nextUrl.pathname}  - w/ params: ${req.nextUrl.searchParams}`
     );
 
     const historikk = kvartalsvisHistorikkMockdata;
@@ -117,8 +114,12 @@ export default async function mockRequest(req: NextRequest) {
       status: 200,
     });
   }
-  if (req.url?.includes("/api/sykefravarsstatistikk-api/publiseringsdato")) {
-    console.log(`[DEBUG] GET /api/sykefravarsstatistikk-api/publiseringsdato`);
+  if (req.nextUrl.pathname.includes("/api/sykefravarsstatistikk-api/publiseringsdato")
+      || req.nextUrl.pathname.includes("/api/authenticated/sykefravarsstatistikk/v2/publiseringsdato")
+  ) {
+    console.log(
+        `[DEBUG] GET ${req.nextUrl.pathname}  - w/ params: ${req.nextUrl.searchParams}`
+    );
 
     const publiseringsdato = {
       gjeldendePeriode: {

--- a/src/utils/konstanter.ts
+++ b/src/utils/konstanter.ts
@@ -1,4 +1,5 @@
 export const API_BASE_PATH = "/forebygge-fravar/api";
+export const API_BASE_PATH_V2 = "/forebygge-fravar/api/authenticated/sykefravarsstatistikk/v2";
 export const AUTHENTICATED_BASE_PATH = API_BASE_PATH + "/authenticated";
 export const SYKEFRAVARSSTATISTIKK_BASE_PATH =
   AUTHENTICATED_BASE_PATH + "/sykefravarsstatistikk";


### PR DESCRIPTION
Bruk av en midlertidig `erV2` flag i localstorage for å kunne switche mellom endepunkter i `pia-sykefraværsstatistikk` (v2) og `sykefraværsstatistikk-api` 