### PR TITLE
Fjerne be om tilgang

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - bruk-v2-path-til-s19k
+      - fjerne-be-om-tilgang
     paths-ignore:
       - "**.md"
       - "**/**.md"

--- a/src/Forside/Sykefraværsstatistikk/Sykefraværsstatistikk.test.tsx
+++ b/src/Forside/Sykefraværsstatistikk/Sykefraværsstatistikk.test.tsx
@@ -138,6 +138,7 @@ describe("Sykefraværsstatistikk", () => {
     expect(prosent.textContent).toBe("8,8%");
   });
 
+  /* TODO: denne testen kan bli reaktivert etter Altinn 3 har lansert "Be om tilgang" i Altinn
   it("viser lenke til sykefraværsstatistikken og forklaringstekst", async () => {
     render(
       <Sykefraværsstatistikk
@@ -154,7 +155,9 @@ describe("Sykefraværsstatistikk", () => {
       "Klikk her for å be om tilgang for å se denne virksomhetens sykefraværsstatistikk.",
     );
   });
-
+*/
+  
+  /* TODO: denne testen kan bli reaktivert etter Altinn 3 har lansert "Be om tilgang" i Altinn
   it("lenker riktig til sykefraværsstatistikken", async () => {
     render(
       <Sykefraværsstatistikk
@@ -173,6 +176,7 @@ describe("Sykefraværsstatistikk", () => {
       expect.stringContaining("http://url?bedrift=999999999"),
     );
   });
+  */
 
   test("uu-feil fra axe", async () => {
     let { container } = render(

--- a/src/Forside/Sykefraværsstatistikk/Sykefraværsstatistikk.tsx
+++ b/src/Forside/Sykefraværsstatistikk/Sykefraværsstatistikk.tsx
@@ -148,8 +148,8 @@ function Sykefraværsstatistikkinnhold({
 
   return (
     <Lenkeflis
-      overskrift="Be om tilgang"
-      brødtekst="Klikk her for å be om tilgang for å se denne virksomhetens sykefraværsstatistikk."
+        overskrift="Sykefraværsstatistikken"
+        brødtekst="Du mangler tilgang i Altinn for å kunne se tall for denne virksomheten."
       href={sykefraværsstatistikkUrlMedBedrift}
     />
   );

--- a/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.module.css
+++ b/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.module.css
@@ -25,6 +25,10 @@
   margin-bottom: 1.5rem;
 }
 
+.mangler-rettigheter-i-altinn__overskrifter {
+  margin-bottom: 2rem;
+}
+
 .mangler-rettigheter-i-altinn__tekst-wrapper {
   justify-content: center;
 }

--- a/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.test.tsx
+++ b/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.test.tsx
@@ -15,29 +15,31 @@ jest.mock("../../../hooks/useOrgnr", () => ({
 }));
 
 describe("Tester side for manglende Altinn-rettigheter", () => {
-  it("Viser lenke til Altinn med riktig orgnr", () => {
-    const valgtOrgnr = fleskOgFisk[1].OrganizationNumber;
-    jest.spyOn(hooks, "useOrgnr").mockReturnValue(valgtOrgnr);
+  /* TODO: denne testen kan bli reaktivert etter Altinn 3 har lansert "Be om tilgang" i Altinn
+    it("Viser lenke til Altinn med riktig orgnr", () => {
+      const valgtOrgnr = fleskOgFisk[1].OrganizationNumber;
+      jest.spyOn(hooks, "useOrgnr").mockReturnValue(valgtOrgnr);
 
-    const organisasjoner: RestAltinnOrganisasjoner = {
-      status: RestStatus.Suksess,
-      data: fleskOgFisk,
-    };
+      const organisasjoner: RestAltinnOrganisasjoner = {
+        status: RestStatus.Suksess,
+        data: fleskOgFisk,
+      };
 
-    render(
-      <ManglerRettigheterIAltinnSide
-        restOrganisasjonerMedStatistikk={organisasjoner}
-      />
-    );
+      render(
+        <ManglerRettigheterIAltinnSide
+          restOrganisasjonerMedStatistikk={organisasjoner}
+        />
+      );
 
-    const beOmTilgangLenke = screen.getByRole("link", {
-      name: "altinn-logo Be om tilgang i Altinn Gå til Altinn og be om tilgang til tjenesten. Du kan velge hvem i virksomheten som får forespørselen.",
-    }) as HTMLAnchorElement;
+      const beOmTilgangLenke = screen.getByRole("link", {
+        name: "altinn-logo Be om tilgang i Altinn Gå til Altinn og be om tilgang til tjenesten. Du kan velge hvem i virksomheten som får forespørselen.",
+      }) as HTMLAnchorElement;
 
-    expect(beOmTilgangLenke.href).toBe(
-      `https://altinn.no/ui/DelegationRequest?offeredBy=${valgtOrgnr}&resources=3403_2`
-    );
-  });
+      expect(beOmTilgangLenke.href).toBe(
+        `https://altinn.no/ui/DelegationRequest?offeredBy=${valgtOrgnr}&resources=3403_2`
+      );
+    });
+  */
 
   it("Viser lenke til Min Side Arbeidsgiver", () => {
     const valgtBedriftUtenSykefraværsstatistikkRettigheter =

--- a/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.tsx
+++ b/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/ManglerRettigheterIAltinnSide.tsx
@@ -2,52 +2,60 @@ import React from "react";
 import informasjonsirkelSvg from "./informasjon-sirkel.svg";
 import styles from "./ManglerRettigheterIAltinnSide.module.css";
 import { OrganisasjonerMedTilgangListe } from "./OrganisasjonerMedTilgangListe/OrganisasjonerMedTilgangListe";
-import { BeOmTilgang } from "./BeOmTilgang/BeOmTilgang";
 import EksternLenke from "../../felleskomponenter/EksternLenke/EksternLenke";
 import { BodyShort, Heading } from "@navikt/ds-react";
 import { RestAltinnOrganisasjoner } from "../../../integrasjoner/altinnorganisasjon-api";
 import Image from "next/image";
 
 interface Props {
-  restOrganisasjonerMedStatistikk: RestAltinnOrganisasjoner;
+    restOrganisasjonerMedStatistikk: RestAltinnOrganisasjoner;
 }
 
 export const ManglerRettigheterIAltinnSide: React.FunctionComponent<Props> = ({
-  restOrganisasjonerMedStatistikk,
-}) => {
-  return (
-    <div className={styles["mangler-rettigheter-i-altinn__wrapper"]}>
-      <div className={styles["mangler-rettigheter-i-altinn"]}>
-        <div className={styles["mangler-rettigheter-i-altinn__tekst_og_ikon"]}>
-          <Image
-            src={informasjonsirkelSvg}
-            className={
-              styles["mangler-rettigheter-i-altinn__tekst_og_ikon__ikon"]
-            }
-            alt="informasjonsirkel"
-          />
-          <Heading level="2" size={"medium"}>
-            Du mangler rettigheter i Altinn
-          </Heading>
+                                                                                  restOrganisasjonerMedStatistikk,
+                                                                              }) => {
+    const harRestOrganisasjonerMedStatistikk = restOrganisasjonerMedStatistikk.status === "Suksess" && restOrganisasjonerMedStatistikk.data.length > 0;
+    return (
+        <div className={styles["mangler-rettigheter-i-altinn__wrapper"]}>
+            <div className={styles["mangler-rettigheter-i-altinn"]}>
+                <div className={styles["mangler-rettigheter-i-altinn__tekst_og_ikon"]}>
+                    <Image
+                        src={informasjonsirkelSvg}
+                        className={
+                            styles["mangler-rettigheter-i-altinn__tekst_og_ikon__ikon"]
+                        }
+                        alt="informasjonsirkel"
+                    />
+                    <Heading level="2" size={"medium"}>
+                        Du mangler tilgang i Altinn
+                    </Heading>
+                </div>
+
+                <div className={styles["mangler-rettigheter-i-altinn__overskrifter"]}>
+                    <BodyShort
+                        className={styles["mangler-rettigheter-i-altinn__overskrift"]}
+                        spacing
+                    >
+                        Du mangler tilgang i Altinn for å se sykefraværsstatistikk
+                        for denne virksomheten. Ta kontakt med den i organisasjonen din som kan delegere tilganger.
+                    </BodyShort>
+                    <BodyShort
+                        className={styles["mangler-rettigheter-i-altinn__overskrift"]}
+                        spacing
+                    >
+                        Altinn-tilgangen heter &quot;Virksomhetens legemeldte sykefraværsstatistikk&quot;.
+                    </BodyShort>
+                </div>
+
+                {harRestOrganisasjonerMedStatistikk &&
+                    <OrganisasjonerMedTilgangListe
+                        restOrganisasjonerMedStatistikk={restOrganisasjonerMedStatistikk}
+                    />
+                }
+                <EksternLenke href="https://arbeidsgiver.nav.no/min-side-arbeidsgiver/informasjon-om-tilgangsstyring">
+                    Les mer om hvordan tilgangsstyringen i Altinn fungerer
+                </EksternLenke>
+            </div>
         </div>
-
-        <BodyShort
-          className={styles["mangler-rettigheter-i-altinn__overskrift"]}
-          spacing
-        >
-          Du har ikke Altinn-tilgangen du trenger for å se sykefraværsstatistikk
-          for denne virksomheten. Bytt til en virksomhet der du har tilgang
-          eller be om tilgang i Altinn for denne virksomheten.
-        </BodyShort>
-        <BeOmTilgang />
-
-        <OrganisasjonerMedTilgangListe
-          restOrganisasjonerMedStatistikk={restOrganisasjonerMedStatistikk}
-        />
-        <EksternLenke href="https://arbeidsgiver.nav.no/min-side-arbeidsgiver/informasjon-om-tilgangsstyring">
-          Les mer om hvordan tilgangsstyringen i Altinn fungerer
-        </EksternLenke>
-      </div>
-    </div>
-  );
+    );
 };

--- a/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/OrganisasjonerMedTilgangListe/OrganisasjonerMedTilgangListe.tsx
+++ b/src/sykefravarsstatistikk/FeilSider/ManglerRettigheterIAltinnSide/OrganisasjonerMedTilgangListe/OrganisasjonerMedTilgangListe.tsx
@@ -18,7 +18,7 @@ export const OrganisasjonerMedTilgangListe: FunctionComponent<Props> = ({
     <Accordion className={styles["organisasjoner-med-tilgang-liste"]}>
       <Accordion.Item>
         <Accordion.Header>
-          Disse virksomhetene har tilgang til sykefraværsstatistikk
+          Du har tilgang til sykefraværsstatistikk for disse virksomhetene
         </Accordion.Header>
         <Accordion.Content>
           <ul className={styles["organisasjoner-med-tilgang-liste__liste"]}>


### PR DESCRIPTION
I Altinn 3 er det ikke mulig lenger å lenke til "Be om tilgang"
Denne funksjonaliteten vil sannsynligvis komme tilbake senere i Altinn. I mellomtiden må vi skru av muligheten for bruker som ikke har enkeltrettighet "sykefraværsstatistikk" for å be om tilgang direkte i Altinn. 