### PR TITLE
Oppdater avhengigheter

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - upgrade-avhengigheter-3-06-2026
+      - forbedre-logs-cache
     paths-ignore:
       - "**.md"
       - "**/**.md"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-slim@sha256:0f0a6a7959d81a3d8bb447199b2dd9c60a9858ed36fdaaca9fa0427c0cdb4c6b
 
 ENV PORT=3000 \
-    NODE_ENV=production
-# Disable additional cache mechanisms that might cause mkdir errors
-ENV NEXT_TELEMETRY_DISABLED=1
-ENV NEXT_DISABLE_CACHE=1
+    NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
 # Set cache directory to writable location
 ENV NEXT_CACHE_DIR=/tmp/.next/cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-slim@sha256:0f0a6a7959d81a3d8bb447199b2dd9c60a9858ed36fdaaca9fa0427c0cdb4c6b
 
 ENV PORT=3000 \
-    NODE_ENV=production \
-    NEXT_TELEMETRY_DISABLED=1
+    NODE_ENV=production
+# Disable additional cache mechanisms that might cause mkdir errors
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_DISABLE_CACHE=1
+# Set cache directory to writable location
+ENV NEXT_CACHE_DIR=/tmp/.next/cache
 
 COPY --chown=node:node .next/standalone ./
 COPY --chown=node:node .next/static ./.next/static

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22-slim@sha25
 ENV PORT=3000 \
     NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1
-# Set cache directory to writable location
-ENV NEXT_CACHE_DIR=/tmp/.next/cache
 
 COPY --chown=node:node .next/standalone ./
 COPY --chown=node:node .next/static ./.next/static

--- a/package.json
+++ b/package.json
@@ -74,9 +74,5 @@
     "sass": "^1.100.0",
     "typescript-eslint": "^8.60.0",
     "whatwg-fetch": "^3.6.20"
-  },
-  "resolutions": {
-    "@types/react": "19.2.15",
-    "@types/react-dom": "19.2.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': 19.2.15
   '@types/react-dom': 19.2.3
+  js-cookie: 3.0.7
 
 importers:
 
@@ -2894,9 +2895,9 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4747,7 +4748,7 @@ snapshots:
     dependencies:
       csp-header: 6.3.1
       html-react-parser: 5.2.17(@types/react@19.2.15)(react@19.2.6)
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
     optionalDependencies:
       react: 19.2.6
 
@@ -5930,7 +5931,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.4.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0))(eslint@10.4.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0)
       eslint-plugin-react: 7.37.5(eslint@10.4.0)
@@ -5957,7 +5958,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0))(eslint@10.4.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5972,14 +5973,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0))(eslint@10.4.0))(eslint@10.4.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.0)(typescript@5.9.3)
       eslint: 10.4.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0))(eslint@10.4.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5994,7 +5995,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint@10.4.0))(eslint@10.4.0))(eslint@10.4.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0)
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7047,7 +7048,7 @@ snapshots:
 
   jose@6.2.3: {}
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@types/react': 19.2.15
   '@types/react-dom': 19.2.3
   js-cookie: 3.0.7
+  postcss: 8.5.10
 
 importers:
 
@@ -3260,8 +3261,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -7230,7 +7231,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.6)
@@ -7428,7 +7429,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 overrides:
-  js-cookie: "3.0.7"
   '@types/react': "19.2.15"
   '@types/react-dom': "19.2.3"
+  js-cookie: "3.0.7"
+  postcss: "8.5.10"
 
 allowBuilds:
   '@parcel/watcher': true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+overrides:
+  js-cookie: "3.0.7"
+  '@types/react': "19.2.15"
+  '@types/react-dom': "19.2.3"
+
 allowBuilds:
   '@parcel/watcher': true
   core-js: true


### PR DESCRIPTION
Flere endringer i denne:
 - bruk av pnpm native konfig i pnpm-workspace for override som erstatter legacy yarn konfig i package.json
 - oppdatere (via `overrides`) js-cookie og postcss pga dependabot alerts
 - flyte opprettelse av cache til `/tmp` på serveren slik at vi unngår feilmeldingen "Error: ENOENT: no such file or directory, mkdir '/app/.next/cache" 
